### PR TITLE
Update Coherence dependency to 22.06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,15 +30,15 @@
 
         <version.lib.awaitility>4.1.1</version.lib.awaitility>
         <version.lib.bedrock>5.0.16</version.lib.bedrock>
-        <version.lib.coherence>21.12.4</version.lib.coherence>
-        <version.lib.coherence-spring>3.2.0</version.lib.coherence-spring>
+        <version.lib.coherence>22.06</version.lib.coherence>
+        <version.lib.coherence-spring>3.3.0</version.lib.coherence-spring>
         <version.lib.junit>5.7.2</version.lib.junit>
         <version.lib.lombok>1.18.18</version.lib.lombok>
         <version.lib.rest-assured>4.3.3</version.lib.rest-assured>
-        <version.lib.spring-boot>2.6.7</version.lib.spring-boot>
-        <version.lib.spring-cloud>2021.0.2</version.lib.spring-cloud>
+        <version.lib.spring-boot>2.7.1</version.lib.spring-boot>
+        <version.lib.spring-cloud>2021.0.3</version.lib.spring-cloud>
         <version.lib.spring-cloud-starter-feign>1.4.7.RELEASE</version.lib.spring-cloud-starter-feign>
-        <version.lib.springdoc-openapi>1.5.7</version.lib.springdoc-openapi>
+        <version.lib.springdoc-openapi>1.6.9</version.lib.springdoc-openapi>
 
         <version.plugin.jib>3.1.4</version.plugin.jib>
         <version.plugin.failsafe>2.22.2</version.plugin.failsafe>


### PR DESCRIPTION
- Update Spring Boot to 2.7.1
- Update Coherence Spring to 3.3.0
- Update springdoc-openapi to 1.6.9
- Update Spring Cloud to 2021.0.3