### PR TITLE
Add build_spec.yaml as preparation for Oracle's GitHub repository guideline checks

### DIFF
--- a/build_spec.yaml
+++ b/build_spec.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+
+steps:
+  - type: Command
+    name: "compress the repo"
+    command: |
+      tar -cvzf repo.tgz ./
+outputArtifacts:
+  - name: artifact
+    type: BINARY
+    location: ${OCI_PRIMARY_SOURCE_DIR}/repo.tgz


### PR DESCRIPTION
Add build_spec.yaml as preparation for Oracle's GitHub repository guideline checks