### PR TITLE
Revert "Bump org.springframework:spring-web from 6.1.14 to 6.2.0 (#178)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <version.lib.spring-boot>3.3.5</version.lib.spring-boot>
         <version.lib.spring-cloud>2023.0.3</version.lib.spring-cloud>
         <version.lib.springdoc-openapi>2.6.0</version.lib.springdoc-openapi>
-        <version.lib.springframework>6.2.0</version.lib.springframework>
+        <version.lib.springframework>6.1.14</version.lib.springframework>
         <version.lib.opentracing-spring-jaeger>3.3.1</version.lib.opentracing-spring-jaeger>
         <version.lib.jackson>2.18.1</version.lib.jackson>
         <version.lib.jaeger-client>1.8.1</version.lib.jaeger-client>


### PR DESCRIPTION
This reverts commit 487b3dbc45f835ad6607f91389e29e5000a286dd.