### PR TITLE
Version bumps to resolve Trivy scan failures

### DIFF
--- a/carts/pom.xml
+++ b/carts/pom.xml
@@ -127,6 +127,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.lib.tomcat}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -125,6 +125,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.lib.tomcat}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -145,6 +145,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.lib.tomcat}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -132,6 +132,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.lib.tomcat}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,14 @@
         <version.lib.coherence-spring>4.3.0</version.lib.coherence-spring>
         <version.lib.commons-io>2.18.0</version.lib.commons-io>
         <version.lib.httpclient>5.3.1</version.lib.httpclient>
+        <version.lib.logback>1.5.16</version.lib.logback>
         <version.lib.lombok>1.18.28</version.lib.lombok>
         <version.lib.rest-assured>5.5.0</version.lib.rest-assured>
         <version.lib.spring-boot>3.3.5</version.lib.spring-boot>
         <version.lib.spring-cloud>2023.0.4</version.lib.spring-cloud>
         <version.lib.springdoc-openapi>2.6.0</version.lib.springdoc-openapi>
         <version.lib.springframework>6.1.14</version.lib.springframework>
+        <version.lib.tomcat>10.1.34</version.lib.tomcat>
         <version.lib.opentracing-spring-jaeger>3.3.1</version.lib.opentracing-spring-jaeger>
         <version.lib.jackson>2.18.2</version.lib.jackson>
         <version.lib.jaeger-client>1.8.1</version.lib.jaeger-client>

--- a/shipping/pom.xml
+++ b/shipping/pom.xml
@@ -125,6 +125,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.lib.tomcat}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/sockshop-test/pom.xml
+++ b/sockshop-test/pom.xml
@@ -71,6 +71,16 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>${version.lib.jackson}</version>
 		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>${version.lib.logback}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>${version.lib.tomcat}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/users/pom.xml
+++ b/users/pom.xml
@@ -160,6 +160,16 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>${version.lib.jackson}</version>
 		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>${version.lib.logback}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>${version.lib.tomcat}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.awaitility</groupId>


### PR DESCRIPTION
- bump logback to 1.5.16
- bump tomcat-embed-core 10.1.34