### PR TITLE
Trivy updates

### DIFF
--- a/carts/pom.xml
+++ b/carts/pom.xml
@@ -127,6 +127,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <artifactId>logback-core</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <artifactId>logback-classic</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -125,6 +125,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <artifactId>logback-core</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <artifactId>logback-classic</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/orders/pom.xml
+++ b/orders/pom.xml
@@ -145,6 +145,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <artifactId>logback-core</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <artifactId>logback-classic</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -132,6 +132,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <artifactId>logback-core</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <artifactId>logback-classic</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <version.lib.coherence-spring>4.3.0</version.lib.coherence-spring>
         <version.lib.commons-io>2.18.0</version.lib.commons-io>
         <version.lib.httpclient>5.3.1</version.lib.httpclient>
+        <version.lib.logback>1.5.16</version.lib.logback>
         <version.lib.lombok>1.18.28</version.lib.lombok>
         <version.lib.rest-assured>5.5.0</version.lib.rest-assured>
         <version.lib.spring-boot>3.3.7</version.lib.spring-boot>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.lib.httpclient>5.3.1</version.lib.httpclient>
         <version.lib.lombok>1.18.28</version.lib.lombok>
         <version.lib.rest-assured>5.5.0</version.lib.rest-assured>
-        <version.lib.spring-boot>3.3.5</version.lib.spring-boot>
+        <version.lib.spring-boot>3.3.7</version.lib.spring-boot>
         <version.lib.spring-cloud>2023.0.4</version.lib.spring-cloud>
         <version.lib.springdoc-openapi>2.6.0</version.lib.springdoc-openapi>
         <version.lib.springframework>6.1.14</version.lib.springframework>

--- a/shipping/pom.xml
+++ b/shipping/pom.xml
@@ -125,6 +125,16 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${version.lib.jackson}</version>
         </dependency>
+        <dependency>
+            <artifactId>logback-core</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
+        <dependency>
+            <artifactId>logback-classic</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <version>${version.lib.logback}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/sockshop-test/pom.xml
+++ b/sockshop-test/pom.xml
@@ -71,6 +71,16 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>${version.lib.jackson}</version>
 		</dependency>
+		<dependency>
+			<artifactId>logback-core</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<version>${version.lib.logback}</version>
+		</dependency>
+		<dependency>
+			<artifactId>logback-classic</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<version>${version.lib.logback}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/users/pom.xml
+++ b/users/pom.xml
@@ -160,6 +160,16 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>${version.lib.jackson}</version>
 		</dependency>
+		<dependency>
+			<artifactId>logback-core</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<version>${version.lib.logback}</version>
+		</dependency>
+		<dependency>
+			<artifactId>logback-classic</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<version>${version.lib.logback}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.awaitility</groupId>


### PR DESCRIPTION
Bump Spring Boot to 3.3.7
Override logback-{core,classic} to 1.5.16 (has been fixed in Spring Boot already, but hasn't been released)